### PR TITLE
Add syntastic integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ member functions of all global objects (`meson` and `*_machine`). Type object
 name, dot and ``ctrl-x ctrl-o`` to trigger function name completion. Further
 customisations are documented in the help file: ``:help mesonic``.
 
+### Syntastic integration
+
+Mesonic provides a Syntastic syntax checker for the C language. In order to use
+it, put the following (or similar) into your ``.vimrc``.
+
+```vim
+" If there's a `meson.build` file, use meson for linting.
+autocmd FileType c call ConsiderMesonForLinting()
+function ConsiderMesonForLinting()
+    if filereadable('meson.build')
+        let g:syntastic_c_checkers = ['meson']
+    endif
+endfunction
+```
+
 ## Limitations
 
 Mesonic assumes that build directory is a subdirectory of top-level directory of

--- a/compiler/meson.vim
+++ b/compiler/meson.vim
@@ -11,20 +11,9 @@ function! s:GetCwdRelativeToProjectDirectory(project_dir)
 	return substitute(getcwd().'/', fnameescape(a:project_dir), '', 'g')
 endfunction
 
-" Ninja build executable (defaults to 'ninja')
-function! s:NinjaCommand()
-	let l:cmd = 'ninja'
-	if exists('b:meson_ninja_command')
-		let l:cmd = b:meson_ninja_command
-	elseif exists('g:meson_ninja_command')
-		let l:cmd = g:meson_ninja_command
-	endif
-	return l:cmd
-endfunction
-
 function! s:SetMakeProgramme(project_dir)
 	let l:build_dir = g:MesonBuildDir(a:project_dir)
-	let &l:makeprg =  s:NinjaCommand() . ' -C ' . l:build_dir
+	let &l:makeprg =  g:NinjaCommand() . ' -C ' . l:build_dir
 endfunction
 
 " Split error format on commas taking into account edge cases.

--- a/plugin/meson.vim
+++ b/plugin/meson.vim
@@ -42,12 +42,23 @@ function! g:MesonBuildDir(project_dir)
 endfunction
 
 " Meson build executable (defaults to 'meson')
-function! s:MesonCommand()
+function! g:MesonCommand()
 	let l:cmd = 'meson'
 	if exists('b:meson_command')
 		let l:cmd = b:meson_command
 	elseif exists('g:meson_command')
 		let l:cmd = g:meson_command
+	endif
+	return l:cmd
+endfunction
+
+" Ninja build executable (defaults to 'ninja')
+function! g:NinjaCommand()
+	let l:cmd = 'ninja'
+	if exists('b:meson_ninja_command')
+		let l:cmd = b:meson_ninja_command
+	elseif exists('g:meson_ninja_command')
+		let l:cmd = g:meson_ninja_command
 	endif
 	return l:cmd
 endfunction
@@ -73,7 +84,7 @@ function! g:MesonInit(...)
 	let l:relative_build_dir = fnamemodify(l:build_dir, ':p:h:t')
 	if !filereadable(l:build_dir . '/build.ninja')
 		echo 'Initialising ' . l:relative_build_dir
-		echo system(s:MesonCommand() . ' ' . l:project_dir . ' ' . l:build_dir)
+		echo system(g:MesonCommand() . ' ' . l:project_dir . ' ' . l:build_dir)
 	else
 		echo 'Switching to ' . l:relative_build_dir
 		let g:meson_build_dir = l:relative_build_dir

--- a/syntax_checkers/c/meson.vim
+++ b/syntax_checkers/c/meson.vim
@@ -18,7 +18,7 @@ set cpo&vim
 
 function! SyntaxCheckers_c_meson_IsAvailable() dict
     return executable(self.getExec()) &&
-        \ executable('meson') &&
+        \ executable(g:MesonCommand()) &&
         \ filereadable('meson.build') &&
         \ syntastic#util#versionIsAtLeast(self.getVersion(), [0, 16, 0])
 endfunction
@@ -44,7 +44,7 @@ endfunction
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'c',
     \ 'name': 'meson',
-    \ 'exec': 'ninja'
+    \ 'exec': g:NinjaCommand()
     \ })
 
 let &cpo = s:save_cpo

--- a/syntax_checkers/c/meson.vim
+++ b/syntax_checkers/c/meson.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! SyntaxCheckers_c_meson_GetLocList() dict
     return SyntasticMake({
-        \ 'makeprg': self.makeprgBuild({ 'exe_before': '(test -d build > /dev/null 2>&1 || meson build) &&', 'args': '-C build' }),
+        \ 'makeprg': self.makeprgBuild({ 'args': '-C build' }),
         \ 'errorformat':
         \     '%-G../%f:%s:,' .
         \     '%-G../%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .

--- a/syntax_checkers/c/meson.vim
+++ b/syntax_checkers/c/meson.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! SyntaxCheckers_c_meson_GetLocList() dict
     return SyntasticMake({
-        \ 'makeprg': self.makeprgBuild({ 'args': '-C build' }),
+        \ 'makeprg': self.makeprgBuild({ 'args': '-C '.g:MesonBuildDir(g:MesonProjectDir()) }),
         \ 'errorformat':
         \     '%-G../%f:%s:,' .
         \     '%-G../%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .

--- a/syntax_checkers/c/meson.vim
+++ b/syntax_checkers/c/meson.vim
@@ -1,0 +1,54 @@
+" Vim syntastic plugin
+" Language:     C
+"
+" See for details on how to add an external Syntastic checker:
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+
+if exists("g:loaded_syntastic_c_meson_checker")
+    finish
+endif
+
+let g:loaded_syntastic_c_meson_checker = 1
+
+" Force syntastic to call ninja without a specific file name
+let g:syntastic_c_meson_fname = ""
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_meson_IsAvailable() dict
+    silent !test -f meson.build > /dev/null 2>&1
+    let meson_build_exists = v:shell_error == 0
+
+    return executable(self.getExec()) &&
+        \ executable('meson') &&
+        \ meson_build_exists &&
+        \ syntastic#util#versionIsAtLeast(self.getVersion(), [0, 16, 0])
+endfunction
+
+function! SyntaxCheckers_c_meson_GetLocList() dict
+    return SyntasticMake({
+        \ 'makeprg': self.makeprgBuild({ 'exe_before': '(test -d build > /dev/null 2>&1 || meson build) &&', 'args': '-C build' }),
+        \ 'errorformat':
+        \     '%-G../%f:%s:,' .
+        \     '%-G../%f:%l: %#error: %#(Each undeclared identifier is reported only%.%#,' .
+        \     '%-G../%f:%l: %#error: %#for each function it appears%.%#,' .
+        \     '%-GIn file included%.%#,' .
+        \     '%-G %#from ../%f:%l\,,' .
+        \     '../%f:%l:%c: %trror: %m,' .
+        \     '../%f:%l:%c: %tarning: %m,' .
+        \     '../%f:%l:%c: %m,' .
+        \     '../%f:%l: %trror: %m,' .
+        \     '../%f:%l: %tarning: %m,'.
+        \     '../%f:%l: %m',
+        \ })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'meson',
+    \ 'exec': 'ninja'
+    \ })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/syntax_checkers/c/meson.vim
+++ b/syntax_checkers/c/meson.vim
@@ -17,12 +17,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_c_meson_IsAvailable() dict
-    silent !test -f meson.build > /dev/null 2>&1
-    let meson_build_exists = v:shell_error == 0
-
     return executable(self.getExec()) &&
         \ executable('meson') &&
-        \ meson_build_exists &&
+        \ filereadable('meson.build') &&
         \ syntastic#util#versionIsAtLeast(self.getVersion(), [0, 16, 0])
 endfunction
 


### PR DESCRIPTION
This PR adds support for Syntastic linting for C via Meson/Ninja.

In my `.vimrc`, I additionally have the following, to enable this syntastic plugin only when there's a `meson.build` in the current directory.

```vim
autocmd FileType c call ConsiderMesonForLinting()
function ConsiderMesonForLinting()
    silent !test -f meson.build > /dev/null 2>&1
    if v:shell_error == 0
        let g:syntastic_c_checkers = ['meson']
    endif
endfunction
```