### PR TITLE
syntax: Detect functions using a regex

### DIFF
--- a/syntax/meson.vim
+++ b/syntax/meson.vim
@@ -21,62 +21,8 @@ syn keyword mesonBool true false
 syn keyword mesonCond if else endif elif and or not
 syn keyword mesonRepeat foreach endforeach
 
-" global builtin functions
-syn keyword mesonBuiltin
-    \ add_global_arguments
-    \ add_global_link_arguments
-    \ add_languages
-    \ add_project_arguments
-    \ add_project_link_arguments
-    \ add_test_setup
-    \ alias_target
-    \ assert
-    \ benchmark
-    \ both_libraries
-    \ build_target
-    \ configuration_data
-    \ configure_file
-    \ custom_target
-    \ declare_dependency
-    \ dependency
-    \ disabler
-    \ environment
-    \ error
-    \ executable
-    \ files
-    \ find_library
-    \ find_program
-    \ generator
-    \ get_option
-    \ gettext
-    \ get_variable
-    \ import
-    \ include_directories
-    \ install_data
-    \ install_headers
-    \ install_man
-    \ install_subdir
-    \ is_disabler
-    \ is_variable
-    \ jar
-    \ join_paths
-    \ library
-    \ message
-    \ option
-    \ project
-    \ run_command
-    \ run_target
-    \ set_variable
-    \ shared_library
-    \ shared_module
-    \ static_library
-    \ subdir
-    \ subdir_done
-    \ subproject
-    \ summary
-    \ test
-    \ vcs_tag
-    \ warning
+" global functions
+syn match mesonBuiltin "\(^\|[^\.]\)\zs\<\h\w*\>\ze\(\s\|\n\)*("
 
 hi link mesonComment Comment
 hi link mesonTodo Todo


### PR DESCRIPTION
Some meson function names are reused as keyword arguments for other functions (`include_directories` for example). This means the coloring of these words based on a fixed list is sometimes incorrect. This commit replaces the detection of functions by using a regex based on the fact that function names are always followed by an opening parenthesis.