### PR TITLE
MesonInit: Explicitly invoke setup command.

### DIFF
--- a/plugin/meson.vim
+++ b/plugin/meson.vim
@@ -80,7 +80,7 @@ function! g:MesonInit(directory, bang)
     if !filereadable(l:build_dir . '/build.ninja')
         let oldmakeprg = &l:makeprg
         let olderrorformat = &l:errorformat
-        let &l:makeprg = g:MesonCommand() . ' ' . l:project_dir . ' ' . l:build_dir
+        let &l:makeprg = g:MesonCommand() . ' setup ' . l:project_dir . ' ' . l:build_dir
         let &l:errorformat = '%f:%l:%c: %m'
         try
             make


### PR DESCRIPTION
For forward compatibility, meson recommends running `meson setup build-dir` instead of `meson build-dir` although the latter works for now and deprecates the latter usage since version 0.64.0. See https://mesonbuild.com/Commands.html#setup.

This commit fixes a warning emitted by meson since version 0.64.0 when the setup command is not explicitly invoked.